### PR TITLE
Refactor URL Parameter code

### DIFF
--- a/group.html
+++ b/group.html
@@ -914,25 +914,24 @@ if (debug) console.log('debug enableShowHideToggling');
 ////   Get UUID from URL      ////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////
 var url_vars = getUrlVars();
-if (url_vars.uuid || url_vars.userId) {
-	if (url_vars.userId) {
-		$("#userId").val(url_vars.userId);
-	} else {
-		$("#userId").val(url_vars.uuid);
-	}
-	$("#groupId").val(url_vars.groupId);
-	$("#maxMembersToFetch").val(url_vars.max);
-	if (url_vars.hide_avatar) {
-		$("#hideAvatar").prop("checked", true);
-	} else {
-		$("#hideAvatar").prop("checked", false);
-	}
-	if (url_vars.clear_chat) {
-		$("#clearNotification").prop("checked", true);
-	} else {
-		$("#clearNotification").prop("checked", false);
-	}
+if (url_vars.hasOwnProperty("userId")) {
+	$("#userId").val(url_vars.userId);
+else if (url_vars.hasOwnProperty("uuid")) {
+	$("#userId").val(url_vars.uuid);
 }
+if (url_vars.hasOwnProperty("groupId")) {
+	$("#groupId").val(url_vars.groupId);
+}
+if (url_vars.hasOwnProperty("max")) {
+	$("#maxMembersToFetch").val(url_vars.max);
+}
+if (url_vars.hasOwnProperty("hide_avatar")) {
+	$("#hideAvatar").prop("checked", !!url_vars.hide_avatar);
+}
+if (url_vars.hasOwnProperty("clear_chat")) {
+    	$("#clearNotification").prop("checked", !!url_vars.clear_chat);
+}
+
 function getUrlVars() {
     // Function found at http://stackoverflow.com/questions/4656843/jquery-get-querystring-from-url#answer-4656873
     var vars = [], hash;

--- a/group.html
+++ b/group.html
@@ -916,7 +916,7 @@ if (debug) console.log('debug enableShowHideToggling');
 var url_vars = getUrlVars();
 if (url_vars.hasOwnProperty("userId")) {
 	$("#userId").val(url_vars.userId);
-elseif (url_vars.hasOwnProperty("uuid")) {
+} else if (url_vars.hasOwnProperty("uuid")) {
 	$("#userId").val(url_vars.uuid);
 }
 if (url_vars.hasOwnProperty("groupId")) {

--- a/group.html
+++ b/group.html
@@ -916,7 +916,7 @@ if (debug) console.log('debug enableShowHideToggling');
 var url_vars = getUrlVars();
 if (url_vars.hasOwnProperty("userId")) {
 	$("#userId").val(url_vars.userId);
-else if (url_vars.hasOwnProperty("uuid")) {
+elseif (url_vars.hasOwnProperty("uuid")) {
 	$("#userId").val(url_vars.uuid);
 }
 if (url_vars.hasOwnProperty("groupId")) {


### PR DESCRIPTION
This will make the url parameters apply independent of whether or not the user id parameter is supplied.

For instance, `https://oldgods.net/habitica/cTheDragons/group.html?uuid=me&groupId=j` would work but `https://oldgods.net/habitica/cTheDragons/group.html?groupId=j` would not. This PR will also mean that the other defaults won't be affected by empty parameters (for instance, including just the user ID would normally clear the Group ID box).