### PR TITLE
Fix small typos

### DIFF
--- a/js/api-limit.js
+++ b/js/api-limit.js
@@ -161,7 +161,7 @@ function makeAjaxCall(call, userId, apiToken, rl){
 										'Waiting for the cat to get off my laptop...',
 										'Hey wake up sleepy server! We have customers!',
 										'Counting the grains in the sands of time',
-										'Rearranging the furniture while your not looking'
+										'Rearranging the furniture while you are not looking'
 									] //Thank you to @ReyBisCO, @Ceran, @MaybeSteveRogers, @BradleyTheGreat, @DebbieS, @SuperSaraA, @ieahleen, @citrusella, @QuartzFox, @BattleOfTheWarwings, @littlepurpleslipper for contributing to some of the sayings 
 
 

--- a/js/api-limit.js
+++ b/js/api-limit.js
@@ -49,7 +49,7 @@ function makeAjaxCall(call, userId, apiToken, rl){
 										'How do you start a dragon?',
 										'Did I break a nail?',
 										'I don' + SINGLEQUOTE + 't need to ask for directions!',
-										'Sword, sheild, food, shoes, I think I have everything for the quest!',
+										'Sword, shield, food, shoes, I think I have everything for the quest!',
 										'Did you hear that? I think something is under the bed...',
 										'Watching the pot boil',
 										'Let' + SINGLEQUOTE + 's see how long it takes paint to dry',
@@ -159,7 +159,7 @@ function makeAjaxCall(call, userId, apiToken, rl){
 										'Building a blanket fort',
 										'Whispering a lullaby to the wind',
 										'Waiting for the cat to get off my laptop...',
-										'Hey wake up sleepy server! We have customers!',
+										'Hey wake up, sleepy server! We have customers!',
 										'Counting the grains in the sands of time',
 										'Rearranging the furniture while you are not looking'
 									] //Thank you to @ReyBisCO, @Ceran, @MaybeSteveRogers, @BradleyTheGreat, @DebbieS, @SuperSaraA, @ieahleen, @citrusella, @QuartzFox, @BattleOfTheWarwings, @littlepurpleslipper for contributing to some of the sayings 


### PR DESCRIPTION
**your -> you are:**

User `aabe567b-aa55-42c1-b612-b7699a7ba9b7` wrote in [Testing & Bug Squashing for Dragon Tools](https://habitica.com/groups/guild/d9a0ec1e-352b-4697-a5d5-fb45c98fb4a3)

> I found a spelling error in the ever-changing waiting messages on the Inbox Data Tool. It vanishes too fast for me to copy it, so not sure this is the exact formulation but I think it says "Rearranging the furniture while your not looking."The point is, it says "your", but it should be "you're".

**sheild -> shield**
**Added a missing coma in "Hey wake up, sleepy server!"**